### PR TITLE
Store route id as an integer instead of a string

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -350,7 +350,7 @@ exports[`scrape Maine 1`] = `
     "url": "https://ropewiki.com/Mount_Katahdin",
     "latitude": 45.9043,
     "longitude": -68.922,
-    "id": "25753",
+    "id": 25753,
     "name": "Mount Katahdin",
     "quality": 5,
     "permit": "No",
@@ -607,7 +607,7 @@ exports[`scrape Maine 1`] = `
     "url": "https://ropewiki.com/Screw_Auger_Falls_Gorge",
     "latitude": 44.57194,
     "longitude": -70.91,
-    "id": "34280",
+    "id": 34280,
     "name": "Screw Auger Falls Gorge",
     "months": [
       "Jun",
@@ -629,7 +629,7 @@ exports[`scrape Maine 1`] = `
     "url": "https://ropewiki.com/Inman%27s_Cave",
     "latitude": 44.2165,
     "longitude": -69.0747,
-    "id": "68718",
+    "id": 68718,
     "name": "Inman's Cave",
     "technicalRating": 3,
     "waterRating": "A",
@@ -644,7 +644,7 @@ exports[`scrape Maine 1`] = `
     "url": "https://ropewiki.com/Bickford_Slides_Canyon",
     "latitude": 44.274,
     "longitude": -70.9843,
-    "id": "68720",
+    "id": 68720,
     "name": "Bickford Slides Canyon",
     "quality": 3,
     "months": [
@@ -667,7 +667,7 @@ exports[`scrape Maine 1`] = `
     "url": "https://ropewiki.com/The_Cataracts",
     "latitude": 44.6351,
     "longitude": -70.8616,
-    "id": "68931",
+    "id": 68931,
     "name": "The Cataracts",
     "quality": 3,
     "technicalRating": 3,
@@ -694,7 +694,7 @@ exports[`scrape Maine 1`] = `
         "route.url": "https://ropewiki.com/Bickford_Slides_Canyon",
         "route.latitude": 44.274,
         "route.longitude": -70.9843,
-        "route.id": "68720",
+        "route.id": 68720,
         "route.name": "Bickford Slides Canyon",
         "route.quality": 3,
         "route.months": [
@@ -728,7 +728,7 @@ exports[`scrape Maine 1`] = `
         "route.url": "https://ropewiki.com/Inman%27s_Cave",
         "route.latitude": 44.2165,
         "route.longitude": -69.0747,
-        "route.id": "68718",
+        "route.id": 68718,
         "route.name": "Inman's Cave",
         "route.technicalRating": 3,
         "route.waterRating": "A",
@@ -753,7 +753,7 @@ exports[`scrape Maine 1`] = `
       "properties": {
         "route.latitude": 45.9043,
         "route.longitude": -68.922,
-        "route.id": "25753",
+        "route.id": 25753,
         "route.name": "Mount Katahdin",
         "route.quality": 5,
         "route.permit": "No",
@@ -781,7 +781,7 @@ exports[`scrape Maine 1`] = `
       "properties": {
         "route.latitude": 45.9043,
         "route.longitude": -68.922,
-        "route.id": "25753",
+        "route.id": 25753,
         "route.name": "Mount Katahdin",
         "route.quality": 5,
         "route.permit": "No",
@@ -809,7 +809,7 @@ exports[`scrape Maine 1`] = `
       "properties": {
         "route.latitude": 45.9043,
         "route.longitude": -68.922,
-        "route.id": "25753",
+        "route.id": 25753,
         "route.name": "Mount Katahdin",
         "route.quality": 5,
         "route.permit": "No",
@@ -837,7 +837,7 @@ exports[`scrape Maine 1`] = `
       "properties": {
         "route.latitude": 45.9043,
         "route.longitude": -68.922,
-        "route.id": "25753",
+        "route.id": 25753,
         "route.name": "Mount Katahdin",
         "route.quality": 5,
         "route.permit": "No",
@@ -865,7 +865,7 @@ exports[`scrape Maine 1`] = `
       "properties": {
         "route.latitude": 45.9043,
         "route.longitude": -68.922,
-        "route.id": "25753",
+        "route.id": 25753,
         "route.name": "Mount Katahdin",
         "route.quality": 5,
         "route.permit": "No",
@@ -893,7 +893,7 @@ exports[`scrape Maine 1`] = `
       "properties": {
         "route.latitude": 45.9043,
         "route.longitude": -68.922,
-        "route.id": "25753",
+        "route.id": 25753,
         "route.name": "Mount Katahdin",
         "route.quality": 5,
         "route.permit": "No",
@@ -921,7 +921,7 @@ exports[`scrape Maine 1`] = `
       "properties": {
         "route.latitude": 45.9043,
         "route.longitude": -68.922,
-        "route.id": "25753",
+        "route.id": 25753,
         "route.name": "Mount Katahdin",
         "route.quality": 5,
         "route.permit": "No",
@@ -949,7 +949,7 @@ exports[`scrape Maine 1`] = `
       "properties": {
         "route.latitude": 45.9043,
         "route.longitude": -68.922,
-        "route.id": "25753",
+        "route.id": 25753,
         "route.name": "Mount Katahdin",
         "route.quality": 5,
         "route.permit": "No",
@@ -977,7 +977,7 @@ exports[`scrape Maine 1`] = `
       "properties": {
         "route.latitude": 45.9043,
         "route.longitude": -68.922,
-        "route.id": "25753",
+        "route.id": 25753,
         "route.name": "Mount Katahdin",
         "route.quality": 5,
         "route.permit": "No",
@@ -1005,7 +1005,7 @@ exports[`scrape Maine 1`] = `
       "properties": {
         "route.latitude": 45.9043,
         "route.longitude": -68.922,
-        "route.id": "25753",
+        "route.id": 25753,
         "route.name": "Mount Katahdin",
         "route.quality": 5,
         "route.permit": "No",
@@ -1033,7 +1033,7 @@ exports[`scrape Maine 1`] = `
       "properties": {
         "route.latitude": 45.9043,
         "route.longitude": -68.922,
-        "route.id": "25753",
+        "route.id": 25753,
         "route.name": "Mount Katahdin",
         "route.quality": 5,
         "route.permit": "No",
@@ -1062,7 +1062,7 @@ exports[`scrape Maine 1`] = `
         "route.url": "https://ropewiki.com/Screw_Auger_Falls_Gorge",
         "route.latitude": 44.57194,
         "route.longitude": -70.91,
-        "route.id": "34280",
+        "route.id": 34280,
         "route.name": "Screw Auger Falls Gorge",
         "route.months": [
           "Jun",
@@ -1095,7 +1095,7 @@ exports[`scrape Maine 1`] = `
         "route.url": "https://ropewiki.com/The_Cataracts",
         "route.latitude": 44.6351,
         "route.longitude": -70.8616,
-        "route.id": "68931",
+        "route.id": 68931,
         "route.name": "The Cataracts",
         "route.quality": 3,
         "route.technicalRating": 3,
@@ -1113,7 +1113,7 @@ exports[`scrape Maine 1`] = `
     {
       "latitude": 44.274,
       "longitude": -70.9843,
-      "id": "68720",
+      "id": 68720,
       "name": "Bickford Slides Canyon",
       "quality": 3,
       "months": [
@@ -1134,7 +1134,7 @@ exports[`scrape Maine 1`] = `
     {
       "latitude": 44.2165,
       "longitude": -69.0747,
-      "id": "68718",
+      "id": 68718,
       "name": "Inman's Cave",
       "technicalRating": 3,
       "waterRating": "A",
@@ -1147,7 +1147,7 @@ exports[`scrape Maine 1`] = `
     {
       "latitude": 45.9043,
       "longitude": -68.922,
-      "id": "25753",
+      "id": 25753,
       "name": "Mount Katahdin",
       "quality": 5,
       "permit": "No"
@@ -1155,7 +1155,7 @@ exports[`scrape Maine 1`] = `
     {
       "latitude": 44.57194,
       "longitude": -70.91,
-      "id": "34280",
+      "id": 34280,
       "name": "Screw Auger Falls Gorge",
       "months": [
         "Jun",
@@ -1175,7 +1175,7 @@ exports[`scrape Maine 1`] = `
     {
       "latitude": 44.6351,
       "longitude": -70.8616,
-      "id": "68931",
+      "id": 68931,
       "name": "The Cataracts",
       "quality": 3,
       "technicalRating": 3,

--- a/src/scrape/scrapeDescriptions.ts
+++ b/src/scrape/scrapeDescriptions.ts
@@ -41,8 +41,8 @@ export async function scrapeDescriptions(routes: RouteV2[]): Promise<RouteV2[]> 
         return await Promise.all(
           routeChunk.map(async index => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const text = xml.mediawiki.page.find((page: any) => page.id[0] === index.id).revision[0]
-              .text[0]._;
+            const text = xml.mediawiki.page.find((page: any) => page.id[0] === String(index.id))
+              .revision[0].text[0]._;
 
             const route: RouteV2 = {
               ...index,

--- a/src/scrape/scrapeIndices.ts
+++ b/src/scrape/scrapeIndices.ts
@@ -92,7 +92,7 @@ export async function scrapeIndices({regions}: FetchIndicesOptions) {
         url: result.fullurl,
         latitude: round(lat, 5),
         longitude: round(lon, 5),
-        id: result.printouts.pageid[0],
+        id: parseInt(result.printouts.pageid[0]),
         name: result.printouts.name[0],
         quality: result.printouts.quality[0] || undefined,
         months: result.printouts.months.length ? result.printouts.months : undefined,

--- a/src/types/v2.ts
+++ b/src/types/v2.ts
@@ -7,7 +7,8 @@ import type {PermitV1} from './v1';
  * to capture all data we need to filter routes while remaining as compact as possible.
  */
 export interface IndexRouteV2 {
-  id: string;
+  /** @asType integer */
+  id: number;
   name: string;
   quality: number | undefined;
   months: MonthV2[] | undefined;
@@ -16,13 +17,9 @@ export interface IndexRouteV2 {
   timeRating: TimeGradeV2 | undefined;
   riskRating: RiskGradeV2 | undefined;
   permit: PermitV2 | undefined;
-  /**
-   * @asType integer
-   */
+  /** @asType integer */
   rappelCountMin: number | undefined;
-  /**
-   * @asType integer
-   */
+  /** @asType integer */
   rappelCountMax: number | undefined;
   rappelLongestMeters: number | undefined;
   vehicle: VehicleV2 | undefined;


### PR DESCRIPTION
I noticed that we are storing route ids as strings even though they are always integers. While we can still make breaking changes, let's consider this one! 