### PR TITLE
Record and log sizes of all output products

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -1186,6 +1186,16 @@ exports[`scrape Maine 1`] = `
       "rappelCountMax": 5,
       "rappelLongestMeters": 15.24
     }
-  ]
+  ],
+  "output/v2/stats.json": {
+    "indexBytes": 1078,
+    "geojsonBytes": 12481,
+    "detailBytesSum": 13946,
+    "detailBytesMean": 2789.2,
+    "detailBytesP50": 2264,
+    "detailBytesP95": 886,
+    "detailBytesP99": 886,
+    "detailBytesMax": 7915
+  }
 }"
 `;

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {syncStack} from './syncStack';
 import {SyncStackOutput} from './syncStack/getStackTemplate';
 import {uploadOutputDir} from './uploadOutputDir';
 import {writeAllSchemas} from './writeAllSchemas';
-import {writeRoutes} from './writeRoutes';
+import {writeOutput} from './writeOutput';
 import {writeTippecanoe} from './writeTippecanoe';
 
 program.option(
@@ -55,7 +55,8 @@ export async function main(argv: string[]) {
   await logger.step(rmOutputDir, []);
   await logger.step(writeAllSchemas, []);
   const routes = await logger.step(scrape, [regions]);
-  await logger.step(writeRoutes, [routes]);
+  const stats = await logger.step(writeOutput, [routes]);
+  logger.outputStats(stats);
   await logger.step(writeTippecanoe, []);
 
   if (!options.local && stack) {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import {identity, isString} from 'lodash';
 import {inspect} from 'util';
+import {WriteOutputStats} from './writeOutput';
 
 /**
  * All messages that get printed to the console should flow through this object.
@@ -70,6 +71,26 @@ class Logger {
       this.inner('log', [chalk.blue(chalk.bold(`End   ${fn.name}`)) + chalk.dim(` ${timeString}`)]);
     });
     return promise;
+  }
+
+  outputStats(stats: WriteOutputStats) {
+    this.inner('log', [chalk.bold(chalk.magenta('Output Stats'))]);
+
+    const longestKey = Math.max(...Object.keys(stats).map(key => key.length));
+
+    for (const [key, value] of Object.entries(stats)) {
+      this.inner('log', [
+        key.padEnd(longestKey),
+        value
+          ? (value / 1000).toLocaleString(undefined, {
+              unit: 'kilobyte',
+              unitDisplay: 'short',
+              style: 'unit',
+              maximumSignificantDigits: 2,
+            })
+          : 'undefined',
+      ]);
+    }
   }
 
   /**

--- a/src/writeOutput.ts
+++ b/src/writeOutput.ts
@@ -61,7 +61,7 @@ export async function writeOutput(routes: RouteV2[]) {
     detailBytesMax: max(detailBytes),
   };
 
-  FS.promises.writeFile('./output/v2/stats.json', JSON.stringify(metadata));
+  FS.promises.writeFile('./output/v2/stats.json', JSON.stringify(metadata, null, '  '));
 
   return metadata;
 }


### PR DESCRIPTION
fix #48 

This PR adds some code that logs the sizes of all output products to the console after doing a data pull
```
Output Stats
indexBytes      2,200 kB
geojsonBytes    75,000 kB
detailBytesSum  170,000 kB
detailBytesMean 16 kB
detailBytesP50  3.6 kB
detailBytesP95  0.93 kB
detailBytesP99  98 kB
detailBytesMax  5,600 kB
```

and stores it all in a file for later analysis
```
{"indexBytes":2180972,"geojsonBytes":74798442,"detailBytesSum":172027589,"detailBytesMean":16175.60780441937,"detailBytesP50":3577,"detailBytesP95":925,"detailBytesP99":98166,"detailBytesMax":5584168}
```

This will give is a consistent baseline for further improvements to the file sizes as part of #53 

Note that tippecanoe already records stats like these about the vector tiles in the `v2/tiles/metadata.json` file