### PR TITLE
Gzip every file in the output dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@aws-sdk/client-cloudformation": "^3.454.0",
     "@aws-sdk/client-s3": "^3.456.0",
     "@mapbox/togeojson": "^0.16.0",
-    "@scree/aws-utils": "^0.10.0",
+    "@scree/aws-utils": "^0.12.0",
     "@scree/eslint-config-quality": "^1.6.0",
     "@scree/quality": "^0.21.0",
     "@turf/helpers": "^6.5.0",

--- a/src/uploadOutputDir.ts
+++ b/src/uploadOutputDir.ts
@@ -8,5 +8,6 @@ export async function uploadOutputDir(s3: S3, outputs: SyncStackOutput) {
     ...outputs,
     LocalPath: './output',
     FileUploadedHandler: ({S3Key, total, done}) => logger.progress(total, done, S3Key),
+    ApplyContentEncoding: 'gzip',
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1259,10 +1259,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@scree/aws-utils@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@scree/aws-utils/-/aws-utils-0.10.0.tgz#4844702ae72e7f57cb1c9825f49315373c49fce2"
-  integrity sha512-aiAbhbDLapxHoACZW4q0FDl8AXuC7QTyNpgqLLK5OMhjquArHowzlM8+APB86tRcmoagmA9qbflT+WBRSZXtrg==
+"@scree/aws-utils@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@scree/aws-utils/-/aws-utils-0.12.0.tgz#396b40fc6169149af2f3bdd6dd088b3a5e6757e0"
+  integrity sha512-/G1vU6KuPFqSii4IBXj4leloJsUmXBqaeazCY/A2tBfiD9XILwN8MZkmxcGqDYDRzlNlHFjQZjBZw0o+pRPKLw==
   dependencies:
     "@aws-sdk/client-cloudformation" "^3.454.0"
     "@aws-sdk/client-s3" "^3.456.0"


### PR DESCRIPTION
This PR adds gzip compression to all of our output products (vector tiles, index json, details json, etc). This results in an enormous reduction in download sizes without any expected changes to the iOS codebase

fix #64

name | before | after | % change |
-|-|-|-
indexBytes          | 2,200 kB | 300 kB | -86%
detailBytesSum   | 170,000 kB |  27,000 kB | -84%
detailBytesMean | 16 kB | 2.6 kB | -83%
detailBytesP50    | 3.6 kB | 0.46 kB | -87%
detailBytesP95    | 0.93 kB | 0.93 kB | -0%
detailBytesP99    | 98 kB | 0.98 kB |  -99%
detailBytesMax    | 5,600 kB | 200 kB | - 96%