### PR TITLE
Use "plain" JSON instead of ND-JSON for output files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ You can make HTTP requests to the API at `http://canyoneer--main.s3.us-west-1.am
 
 The following endpoints are available:
 
-- `/v2/index.json` - all routes as a [newline separated JSON](https://ndjson.org) file using the lightweight `IndexRouteV2` type
-- `/v2/index.geojson` - all route geometries from the KML file as a [newline separated JSON](https://ndjson.org) file using the `GeoJSONRouteV2` type
+- `/v2/index.json` - all routes as a JSON array using the lightweight `IndexRouteV2` type
+- `/v2/index.geojson` - all route geometries as a JSON array from the KML files using the `GeoJSONRouteV2` type
 - `/v2/details/{id}.json` - detailed data for a single route using the `RouteV2` type which includes the HTML description and all geometries from the KML file
-- `/v2/tiles/{z}/{x}/{y}.pbf` - all route geometries from the KML as the `GeoJSONRouteV2` type formatted as [Vector Tiles](https://github.com/mapbox/vector-tile-spec/)
+- `/v2/tiles/{z}/{x}/{y}.pbf` - all route geometries from the KML files as the `GeoJSONRouteV2` type formatted as [Vector Tiles](https://github.com/mapbox/vector-tile-spec/)
 - `/v2/tiles/metadata.json` - a standard Tippecanoe metadata file that describes what's in the vector tiles and how they were generated
 - `/v2/schemas/{type}.json` - JSON schemas for `IndexRouteV2`, `RouteV2`, and `GeoJSONRouteV2`
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -57,40 +57,17 @@ async function readOutputDir(dirPath = 'output') {
             if (coords.z !== Number(tilesMetadata.maxzoom)) {
               return [];
             } else {
-              return [[path, parseVectorTileTile(await FS.promises.readFile(path), coords)]];
+              return [[path, parseVectorTile(await FS.promises.readFile(path), coords)]];
             }
 
             // Path is some other kind of file
           } else {
-            return [[path, parseTextFile(await FS.promises.readFile(path, 'utf-8'))]];
+            return [[path, JSON.parse(await FS.promises.readFile(path, 'utf-8'))]];
           }
         }),
       )
     ).flat(),
   );
-}
-
-/**
- * Try to parse a string as JSON or newline separated JSON for an easier-to-read snapshot.
- * If the string is parsable as neither, return the original string.
- */
-function parseTextFile(input: string) {
-  try {
-    return JSON.parse(input);
-  } catch (error) {
-    // do nothing
-  }
-
-  try {
-    return input
-      .split('\n')
-      .filter(Boolean)
-      .map(line => JSON.parse(line));
-  } catch (error) {
-    // do nothing
-  }
-
-  return input;
 }
 
 /**
@@ -103,7 +80,7 @@ type VectorTileId = {x: number; y: number; z: number};
  * Turn a binary buffer containing a vector tile and it's associated VectorTileId into a
  * GeoJSON object for snapshot inspection.
  */
-function parseVectorTileTile(data: Buffer, {x, y, z}: VectorTileId) {
+function parseVectorTile(data: Buffer, {x, y, z}: VectorTileId) {
   const tile = new VectorTile(new Protobuf(data));
 
   return Object.fromEntries(

--- a/src/writeOutput.ts
+++ b/src/writeOutput.ts
@@ -6,9 +6,9 @@ export async function writeOutput(routes: RouteV2[]) {
   await FS.promises.mkdir('./output/v2/details', {recursive: true});
   await FS.promises.mkdir('./output/v1', {recursive: true});
 
-  const v1Index = new StreamingJSONWriter('./output/v1/index.json');
-  const v2Index = new StreamingJSONWriter('./output/v2/index.json');
-  const v2GeoJSON = new StreamingJSONWriter('./output/v2/index.geojson');
+  const v1Index = new JSONWriteStream('./output/v1/index.json');
+  const v2Index = new JSONWriteStream('./output/v2/index.json');
+  const v2GeoJSON = new JSONWriteStream('./output/v2/index.geojson');
 
   for (const route of routes) {
     v1Index.write(toRouteV1(route));
@@ -24,7 +24,10 @@ export async function writeOutput(routes: RouteV2[]) {
   await Promise.all([v1Index.end(), v2Index.end(), v2GeoJSON.end()]);
 }
 
-class StreamingJSONWriter {
+/**
+ * This class writes JSON objects to a file, line by line
+ */
+class JSONWriteStream {
   private first = true;
   private stream: FS.WriteStream;
 


### PR DESCRIPTION
By popular demand...

This PR formats all output files as "plain" JSON instead of [ND-JSON](https://ndjson.org/libraries.html) 

Fix #71 