### PR TITLE
Add `etag` property to routes in v2/index.json

### DIFF
--- a/src/cli/__snapshots__/index.test.ts.snap
+++ b/src/cli/__snapshots__/index.test.ts.snap
@@ -22,7 +22,8 @@ exports[`scrape Maine 1`] = `
       "permit": "No",
       "rappelCountMin": 3,
       "rappelCountMax": 3,
-      "rappelLongestMeters": 15.24
+      "rappelLongestMeters": 15.24,
+      "etag": "91030b54ddb632ba1263e88115c3efb8"
     },
     {
       "latitude": 44.2165,
@@ -35,7 +36,8 @@ exports[`scrape Maine 1`] = `
       "permit": "No",
       "rappelCountMin": 2,
       "rappelCountMax": 2,
-      "rappelLongestMeters": 6.1
+      "rappelLongestMeters": 6.1,
+      "etag": "6334e113829074173ce334f91d6d9899"
     },
     {
       "latitude": 45.9043,
@@ -43,7 +45,8 @@ exports[`scrape Maine 1`] = `
       "id": 25753,
       "name": "Mount Katahdin",
       "quality": 5,
-      "permit": "No"
+      "permit": "No",
+      "etag": "8e127cca2d437c02de0b12f7666ebf69"
     },
     {
       "latitude": 44.57194,
@@ -63,7 +66,8 @@ exports[`scrape Maine 1`] = `
       "permit": "No",
       "rappelCountMin": 1,
       "rappelCountMax": 1,
-      "rappelLongestMeters": 7.62
+      "rappelLongestMeters": 7.62,
+      "etag": "a36b9c35ad8680760ece4d32fe00335b"
     },
     {
       "latitude": 44.6351,
@@ -77,7 +81,8 @@ exports[`scrape Maine 1`] = `
       "permit": "No",
       "rappelCountMin": 4,
       "rappelCountMax": 5,
-      "rappelLongestMeters": 15.24
+      "rappelLongestMeters": 15.24,
+      "etag": "5e4a0388cb3a285798b7eea1c63087de"
     }
   ],
   "public/v1/index.json": [

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -9,7 +9,7 @@ import {main} from '.';
 import {logger} from '../utils/logger';
 
 // This test can take longer than the default 5 seconds timeout
-const timeout = 60 * 1000;
+const timeout = 120 * 1000;
 
 describe('scrape', () => {
   beforeAll(async () => {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -94,7 +94,7 @@ class Logger {
             style: 'unit',
             maximumSignificantDigits: 2,
           }),
-          ((mainStats[name] - stats[name]) / mainStats[name]).toLocaleString(undefined, {
+          ((stats[name] - mainStats[name]) / mainStats[name]).toLocaleString(undefined, {
             style: 'percent',
             maximumSignificantDigits: 2,
           }),


### PR DESCRIPTION
fix #53 

This PR extends the `v2/index.json` endpoint with an `etag` property for each route. This property reports the ETag of the corresponding `v2/details/[id].json`

# Why ETags?
ETags, essentially checksums of content, offer a robust way to identify changes in data. Unlike last modified dates, which only indicate when the file was last changed, ETags change only when the content of the file changes. This characteristic makes them particularly reliable for data synchronization.

# Implementation for iOS App
 - On the initial fetch, first get `v2/index.json`, and then get each `v2/details/[id].json`. Store the `ETag` header of each details JSON along with its data.
 - On subsequent updates, first get `v2/index.json`. Use the ETags in this index to determine if the route details have changed since the last fetch.
   - If the ETag for a route in the local storage differs from the one in the updated index, it indicates a change in the route details. In this case, fetch the updated `v2/details/[id].json`. Remember to store the new ETag from the response header of this fetch.

# Size Stats 

This PR increases the size of our `v2/index.json` file by 83%. A slow 3g connection is typically 400 Kb/s, so syncing the index take just over 1 second, worst case, for users worldwide.

name            | etag2     | main      | % change
----------------|-----------|-----------|---------
indexBytes      | 540 kB    | 300 kB    | +83%    
geojsonBytes    | 14,000 kB | 14,000 kB | 0%      
detailBytesSum  | 27,000 kB | 27,000 kB | 0%      
detailBytesMean | 2.6 kB    | 2.6 kB    | 0%      
detailBytesP50  | 0.46 kB   | 0.46 kB   | 0%      
detailBytesP95  | 0.93 kB   | 0.93 kB   | 0%      
detailBytesP99  | 9.8 kB    | 9.8 kB    | 0%      
detailBytesMax  | 200 kB    | 200 kB    | 0%      
tileBytesSum    | 12,000 kB | 12,000 kB | 0%      
tileBytesMean   | 0.83 kB   | 0.83 kB   | 0%      
tileBytesP50    | 0.78 kB   | 0.78 kB   | 0%      
tileBytesP95    | 0.22 kB   | 0.22 kB   | 0%      
tileBytesP99    | 1.3 kB    | 1.3 kB    | 0%      
tileBytesMax    | 120 kB    | 120 kB    | 0%   