### PR TITLE
Add "version" property to "IndexRouteV2" and "RouteV2"

### DIFF
--- a/src/cli/__snapshots__/index.test.ts.snap
+++ b/src/cli/__snapshots__/index.test.ts.snap
@@ -23,7 +23,7 @@ exports[`scrape Maine 1`] = `
       "rappelCountMin": 3,
       "rappelCountMax": 3,
       "rappelLongestMeters": 15.24,
-      "etag": "91030b54ddb632ba1263e88115c3efb8"
+      "version": "08d6cdfeffaca1f9dcfe58aeaff62399"
     },
     {
       "latitude": 44.2165,
@@ -37,7 +37,7 @@ exports[`scrape Maine 1`] = `
       "rappelCountMin": 2,
       "rappelCountMax": 2,
       "rappelLongestMeters": 6.1,
-      "etag": "6334e113829074173ce334f91d6d9899"
+      "version": "ce8f19c7f05dffb4a5d55a7d036a0e60"
     },
     {
       "latitude": 45.9043,
@@ -46,7 +46,7 @@ exports[`scrape Maine 1`] = `
       "name": "Mount Katahdin",
       "quality": 5,
       "permit": "No",
-      "etag": "454e07c964b856a37a031a7163269fe0"
+      "version": "3a6023d5dedced4a32951c05c91d6b93"
     },
     {
       "latitude": 44.57194,
@@ -67,7 +67,7 @@ exports[`scrape Maine 1`] = `
       "rappelCountMin": 1,
       "rappelCountMax": 1,
       "rappelLongestMeters": 7.62,
-      "etag": "a36b9c35ad8680760ece4d32fe00335b"
+      "version": "5b69b6d2ea51925a587eb878b20a9d03"
     },
     {
       "latitude": 44.6351,
@@ -82,7 +82,7 @@ exports[`scrape Maine 1`] = `
       "rappelCountMin": 4,
       "rappelCountMax": 5,
       "rappelLongestMeters": 15.24,
-      "etag": "5e4a0388cb3a285798b7eea1c63087de"
+      "version": "7fde5bbc3968af2ecd71133299f41685"
     }
   ],
   "public/v1/index.json": [
@@ -706,7 +706,8 @@ exports[`scrape Maine 1`] = `
           }
         }
       ]
-    }
+    },
+    "version": "3a6023d5dedced4a32951c05c91d6b93"
   },
   "public/v2/details/34280.json": {
     "url": "https://ropewiki.com/Screw_Auger_Falls_Gorge",
@@ -728,7 +729,8 @@ exports[`scrape Maine 1`] = `
     "rappelCountMin": 1,
     "rappelCountMax": 1,
     "rappelLongestMeters": 7.62,
-    "description": "<h2 id=\\"introduction\\">Introduction</h2>\\n<p>\\"The last canyon along the Bear River in Grafton Notch is the Screw\\nAuger Gorge. This short Gorge is probably one of the most popular\\ntourist destinations in the area. It is frequented by thousands of\\ntourists each summer and it is not uncommon to find families and teens\\nswimming here on a warm summer afternoon. The canyoneering opportunities\\nare limited but still possible. Rappel off a natural anchor or tree into\\nthe pothole below, escape the small pothole and hike/ swim through the\\nrest of the gorge.\\"</p>\\n<p>from <em>The Maine Canyon Survey: A Guide to Canyoneering in\\nMaine.</em></p>\\n<p><a\\nhref=\\"https://eyesupadventure.wixsite.com/adventure/maine-canyoneering\\">1</a></p>\\n<h2 id=\\"approach\\">Approach</h2>\\n<h2 id=\\"descent\\">Descent</h2>\\n<h2 id=\\"exit\\">Exit</h2>\\n<h2 id=\\"red_tape\\">Red tape</h2>\\n<h2 id=\\"beta_sites\\">Beta sites</h2>\\n<ul>\\n<li><img src=\\"rwl_en.png\\" title=\\"rwl_en.png\\" alt=\\"rwl_en.png\\" /><a\\nhref=\\"http://summitpost.org/screw-auger-falls-gorge/826303\\">SummitPost.org</a>\\n: Screw Auger Falls Gorge]</li>\\n</ul>\\n<ul>\\n<li><img src=\\"rwl_en.png\\" title=\\"rwl_en.png\\" alt=\\"rwl_en.png\\" /><a\\nhref=\\"https://eyesupadventure.wixsite.com/adventure/maine-canyoneering\\">Eyes\\nUp Adventure</a> : Maine canyoneering]</li>\\n</ul>\\n<h2 id=\\"trip_reports_and_media\\">Trip reports and media</h2>\\n<h2 id=\\"background\\">Background</h2>\\n"
+    "description": "<h2 id=\\"introduction\\">Introduction</h2>\\n<p>\\"The last canyon along the Bear River in Grafton Notch is the Screw\\nAuger Gorge. This short Gorge is probably one of the most popular\\ntourist destinations in the area. It is frequented by thousands of\\ntourists each summer and it is not uncommon to find families and teens\\nswimming here on a warm summer afternoon. The canyoneering opportunities\\nare limited but still possible. Rappel off a natural anchor or tree into\\nthe pothole below, escape the small pothole and hike/ swim through the\\nrest of the gorge.\\"</p>\\n<p>from <em>The Maine Canyon Survey: A Guide to Canyoneering in\\nMaine.</em></p>\\n<p><a\\nhref=\\"https://eyesupadventure.wixsite.com/adventure/maine-canyoneering\\">1</a></p>\\n<h2 id=\\"approach\\">Approach</h2>\\n<h2 id=\\"descent\\">Descent</h2>\\n<h2 id=\\"exit\\">Exit</h2>\\n<h2 id=\\"red_tape\\">Red tape</h2>\\n<h2 id=\\"beta_sites\\">Beta sites</h2>\\n<ul>\\n<li><img src=\\"rwl_en.png\\" title=\\"rwl_en.png\\" alt=\\"rwl_en.png\\" /><a\\nhref=\\"http://summitpost.org/screw-auger-falls-gorge/826303\\">SummitPost.org</a>\\n: Screw Auger Falls Gorge]</li>\\n</ul>\\n<ul>\\n<li><img src=\\"rwl_en.png\\" title=\\"rwl_en.png\\" alt=\\"rwl_en.png\\" /><a\\nhref=\\"https://eyesupadventure.wixsite.com/adventure/maine-canyoneering\\">Eyes\\nUp Adventure</a> : Maine canyoneering]</li>\\n</ul>\\n<h2 id=\\"trip_reports_and_media\\">Trip reports and media</h2>\\n<h2 id=\\"background\\">Background</h2>\\n",
+    "version": "5b69b6d2ea51925a587eb878b20a9d03"
   },
   "public/v2/details/68718.json": {
     "url": "https://ropewiki.com/Inman%27s_Cave",
@@ -743,7 +745,8 @@ exports[`scrape Maine 1`] = `
     "rappelCountMin": 2,
     "rappelCountMax": 2,
     "rappelLongestMeters": 6.1,
-    "description": "<h2 id=\\"introduction\\">Introduction</h2>\\n<p>This is one of the only caves in Maine that requires the use of SRT\\nequipment. The cave is small but makes for a fun adventure. Location\\nbeta and more information can be provided by contacting the Maine Cave\\nSurvey with the following email: stephen.whitney1999@gmail.com</p>\\n<p>If you have visited this cave please do not post location data to\\nkeep riffraff out of dangrous situations!</p>\\n<h2 id=\\"approach\\">Approach</h2>\\n<h2 id=\\"descent\\">Descent</h2>\\n<h2 id=\\"exit\\">Exit</h2>\\n<h2 id=\\"red_tape\\">Red tape</h2>\\n<h2 id=\\"beta_sites\\">Beta sites</h2>\\n<h2 id=\\"trip_reports_and_media\\">Trip reports and media</h2>\\n<h2 id=\\"background\\">Background</h2>\\n"
+    "description": "<h2 id=\\"introduction\\">Introduction</h2>\\n<p>This is one of the only caves in Maine that requires the use of SRT\\nequipment. The cave is small but makes for a fun adventure. Location\\nbeta and more information can be provided by contacting the Maine Cave\\nSurvey with the following email: stephen.whitney1999@gmail.com</p>\\n<p>If you have visited this cave please do not post location data to\\nkeep riffraff out of dangrous situations!</p>\\n<h2 id=\\"approach\\">Approach</h2>\\n<h2 id=\\"descent\\">Descent</h2>\\n<h2 id=\\"exit\\">Exit</h2>\\n<h2 id=\\"red_tape\\">Red tape</h2>\\n<h2 id=\\"beta_sites\\">Beta sites</h2>\\n<h2 id=\\"trip_reports_and_media\\">Trip reports and media</h2>\\n<h2 id=\\"background\\">Background</h2>\\n",
+    "version": "ce8f19c7f05dffb4a5d55a7d036a0e60"
   },
   "public/v2/details/68720.json": {
     "url": "https://ropewiki.com/Bickford_Slides_Canyon",
@@ -766,7 +769,8 @@ exports[`scrape Maine 1`] = `
     "rappelCountMin": 3,
     "rappelCountMax": 3,
     "rappelLongestMeters": 15.24,
-    "description": "<h2 id=\\"introduction\\">Introduction</h2>\\n<p>This gorgeous canyon sits high up in the White Mountains of western\\nMaine. The canyon descends over 400 feet in just a half mile and\\nrequires technical gear for navigation around its four rappels. It may\\nbe one of the most enjoyable descents in western Maine. Spend a fun\\nmorning descending this canyon then hop on over to Rattlesnake Gorge for\\nanother fun descent.</p>\\n<h2 id=\\"approach\\">Approach</h2>\\n<p>The best location to start from is the Brickett Place. There is a day\\nuse fee for this trailhead it was $5.00 in 2021. From the trailhead hike\\nup Bickford Brook Trail past the first trail intersection until you\\nreach the second fork in the trail. (19 T 0341714E 4904338N). Take the\\ntrail on the right at this intersection. The trail will cross over the\\ncreek, follow this creek downstream until you reach the canyon.</p>\\n<h2 id=\\"descent\\">Descent</h2>\\n<p>Wrap a tree and descend 30 ft into the canyon. Continue down canyon\\nuntil you reach the second drop. Wrap another tree and descend 20 ft.\\nFollowing the second rappel hike along the canyon avoiding the pools of\\nwater as much as possible. Turn the corner and wrap another tree or\\nboulder and descend to the large pool at the end of the canyon. Hike\\nalong the stream another 1/4th of a mile to where a trail crosses the\\nstream.</p>\\n<h2 id=\\"exit\\">Exit</h2>\\n<p>Hike out to the trail head on this trail or descend down one last\\nrappel on the other side of this trail.</p>\\n<h2 id=\\"red_tape\\">Red tape</h2>\\n<h2 id=\\"beta_sites\\">Beta sites</h2>\\n<p><a\\nhref=\\"https://eyesupadventure.wixsite.com/adventure/maine-canyoneering\\">https://eyesupadventure.wixsite.com/adventure/maine-canyoneering</a></p>\\n<h2 id=\\"trip_reports_and_media\\">Trip reports and media</h2>\\n<h2 id=\\"background\\">Background</h2>\\n"
+    "description": "<h2 id=\\"introduction\\">Introduction</h2>\\n<p>This gorgeous canyon sits high up in the White Mountains of western\\nMaine. The canyon descends over 400 feet in just a half mile and\\nrequires technical gear for navigation around its four rappels. It may\\nbe one of the most enjoyable descents in western Maine. Spend a fun\\nmorning descending this canyon then hop on over to Rattlesnake Gorge for\\nanother fun descent.</p>\\n<h2 id=\\"approach\\">Approach</h2>\\n<p>The best location to start from is the Brickett Place. There is a day\\nuse fee for this trailhead it was $5.00 in 2021. From the trailhead hike\\nup Bickford Brook Trail past the first trail intersection until you\\nreach the second fork in the trail. (19 T 0341714E 4904338N). Take the\\ntrail on the right at this intersection. The trail will cross over the\\ncreek, follow this creek downstream until you reach the canyon.</p>\\n<h2 id=\\"descent\\">Descent</h2>\\n<p>Wrap a tree and descend 30 ft into the canyon. Continue down canyon\\nuntil you reach the second drop. Wrap another tree and descend 20 ft.\\nFollowing the second rappel hike along the canyon avoiding the pools of\\nwater as much as possible. Turn the corner and wrap another tree or\\nboulder and descend to the large pool at the end of the canyon. Hike\\nalong the stream another 1/4th of a mile to where a trail crosses the\\nstream.</p>\\n<h2 id=\\"exit\\">Exit</h2>\\n<p>Hike out to the trail head on this trail or descend down one last\\nrappel on the other side of this trail.</p>\\n<h2 id=\\"red_tape\\">Red tape</h2>\\n<h2 id=\\"beta_sites\\">Beta sites</h2>\\n<p><a\\nhref=\\"https://eyesupadventure.wixsite.com/adventure/maine-canyoneering\\">https://eyesupadventure.wixsite.com/adventure/maine-canyoneering</a></p>\\n<h2 id=\\"trip_reports_and_media\\">Trip reports and media</h2>\\n<h2 id=\\"background\\">Background</h2>\\n",
+    "version": "08d6cdfeffaca1f9dcfe58aeaff62399"
   },
   "public/v2/details/68931.json": {
     "url": "https://ropewiki.com/The_Cataracts",
@@ -782,7 +786,8 @@ exports[`scrape Maine 1`] = `
     "rappelCountMin": 4,
     "rappelCountMax": 5,
     "rappelLongestMeters": 15.24,
-    "description": "<h2 id=\\"introduction\\">Introduction</h2>\\n<p>Nice Canyon near Andover, ME.</p>\\n<h2 id=\\"approach\\">Approach</h2>\\n<p>Hike up trail to slot.</p>\\n<h2 id=\\"descent\\">Descent</h2>\\n<p>8ft rap into slot, 25ft two tier rap at the end of slot. Another 30\\nft rap and a final 50ft.</p>\\n<h2 id=\\"exit\\">Exit</h2>\\n<p>Hike out trail</p>\\n<h2 id=\\"red_tape\\">Red tape</h2>\\n<h2 id=\\"beta_sites\\">Beta sites</h2>\\n<p>See The Maine Canyon Survey</p>\\n<h2 id=\\"trip_reports_and_media\\">Trip reports and media</h2>\\n<h2 id=\\"background\\">Background</h2>\\n"
+    "description": "<h2 id=\\"introduction\\">Introduction</h2>\\n<p>Nice Canyon near Andover, ME.</p>\\n<h2 id=\\"approach\\">Approach</h2>\\n<p>Hike up trail to slot.</p>\\n<h2 id=\\"descent\\">Descent</h2>\\n<p>8ft rap into slot, 25ft two tier rap at the end of slot. Another 30\\nft rap and a final 50ft.</p>\\n<h2 id=\\"exit\\">Exit</h2>\\n<p>Hike out trail</p>\\n<h2 id=\\"red_tape\\">Red tape</h2>\\n<h2 id=\\"beta_sites\\">Beta sites</h2>\\n<p>See The Maine Canyon Survey</p>\\n<h2 id=\\"trip_reports_and_media\\">Trip reports and media</h2>\\n<h2 id=\\"background\\">Background</h2>\\n",
+    "version": "7fde5bbc3968af2ecd71133299f41685"
   },
   "public/v2/tiles/12/1240/1485.pbf": {
     "routes": [

--- a/src/cli/createPublicRoutes.ts
+++ b/src/cli/createPublicRoutes.ts
@@ -1,4 +1,3 @@
-import {getS3Etag} from '@scree/aws-utils';
 import FS from 'fs';
 import {RouteV2, toGeoJSONRouteV2, toIndexRouteV2, toRouteV1} from '../types/v2';
 
@@ -14,7 +13,7 @@ export async function createPublicRoutes(routes: RouteV2[]) {
     const detailsJSON = Buffer.from(JSON.stringify(route, null, 2));
 
     v1Index.write(toRouteV1(route));
-    v2Index.write(toIndexRouteV2(route, getS3Etag(detailsJSON)));
+    v2Index.write(toIndexRouteV2(route));
     toGeoJSONRouteV2(route).forEach(feature => v2GeoJSON.write(feature));
     await FS.promises.writeFile(`./public/v2/details/${route.id}.json`, detailsJSON);
   }

--- a/src/cli/scrapeRoutes/index.ts
+++ b/src/cli/scrapeRoutes/index.ts
@@ -1,4 +1,6 @@
+import {getS3Etag} from '@scree/aws-utils';
 import {isArray} from 'lodash';
+import {RouteV2} from '../../types/v2';
 import {allRegions} from '../../utils/allRegions';
 import {logger} from '../../utils/logger';
 import {parseKMLs} from './parseKMLs';
@@ -16,5 +18,13 @@ export async function scrapeRoutes(regions: string | string[], cachePath: string
   const descriptions = await logger.step(scrapeDescriptions, [indices, cachePath]);
   const rawGeojson = await logger.step(scrapeKMLs, [descriptions, regions, cachePath]);
   const geojson = await logger.step(parseKMLs, [rawGeojson, cachePath]);
-  return geojson;
+  const versions = logger.step(injectVersions, [geojson]);
+  return versions;
+}
+
+function injectVersions(routes: RouteV2[]) {
+  for (const route of routes) {
+    route['version'] = getS3Etag(Buffer.from(JSON.stringify(route)));
+  }
+  return routes;
 }

--- a/src/cli/scrapeRoutes/index.ts
+++ b/src/cli/scrapeRoutes/index.ts
@@ -1,8 +1,7 @@
-import {getS3Etag} from '@scree/aws-utils';
 import {isArray} from 'lodash';
-import {RouteV2} from '../../types/v2';
 import {allRegions} from '../../utils/allRegions';
 import {logger} from '../../utils/logger';
+import {injectVersions} from './injectVersions';
 import {parseKMLs} from './parseKMLs';
 import {scrapeDescriptions} from './scrapeDescriptions';
 import {scrapeIndices} from './scrapeIndices';
@@ -20,11 +19,4 @@ export async function scrapeRoutes(regions: string | string[], cachePath: string
   const geojson = await logger.step(parseKMLs, [rawGeojson, cachePath]);
   const versions = logger.step(injectVersions, [geojson]);
   return versions;
-}
-
-function injectVersions(routes: RouteV2[]) {
-  for (const route of routes) {
-    route['version'] = getS3Etag(Buffer.from(JSON.stringify(route)));
-  }
-  return routes;
 }

--- a/src/cli/scrapeRoutes/injectVersions.ts
+++ b/src/cli/scrapeRoutes/injectVersions.ts
@@ -1,0 +1,9 @@
+import {getS3Etag} from '@scree/aws-utils';
+import {RouteV2} from '../../types/v2';
+
+export function injectVersions(routes: RouteV2[]) {
+  for (const route of routes) {
+    route['version'] = getS3Etag(Buffer.from(JSON.stringify(route)));
+  }
+  return routes;
+}

--- a/src/cli/scrapeRoutes/scrapeIndices.ts
+++ b/src/cli/scrapeRoutes/scrapeIndices.ts
@@ -108,6 +108,7 @@ export async function scrapeIndices(regions: string[], cachePath: string) {
           result.printouts.shuttle[0]?.value ? result.printouts.shuttle[0].value * 60 : undefined,
         description: undefined, // this is populated by `scrapeDescription` later
         geojson: undefined, // this is populated by `scrapeKMLs` later
+        version: '', // this is populated by `injectVersions` later
       };
 
       validateSchema('RouteV2', route);

--- a/src/types/v2.ts
+++ b/src/types/v2.ts
@@ -34,17 +34,16 @@ export interface IndexRouteV2 {
   longitude: number;
 
   /**
-   * This is the ETag of the details JSON file. If the ETag changes, clients know they should fetch
-   * an updated version of the details JSON file.
+   * This opaque string is a checksum of the associated details file at `v2/details/[id].json`.
    */
-  etag: string;
+  version: string;
 }
 
 /**
  * This "detailed" type is used in `details/{id}.json`. It is the source of truth for all data
  * we have on a particular route.
  */
-export interface RouteV2 extends Omit<IndexRouteV2, 'etag'> {
+export interface RouteV2 extends IndexRouteV2 {
   url: string;
   description: string | undefined;
   geojson: FeatureCollection | undefined;
@@ -53,7 +52,7 @@ export interface RouteV2 extends Omit<IndexRouteV2, 'etag'> {
 type GeoJSONRouteV2CoreProperties = {
   [Key in keyof Omit<
     IndexRouteV2,
-    'months' | 'latitude' | 'longitude' | 'etag'
+    'months' | 'latitude' | 'longitude' | 'version'
   > as `route.${Key}`]: IndexRouteV2[Key];
 } & {
   // Vector tiles cannot encode arrays so we break the months out into individual properties.
@@ -121,8 +120,8 @@ export type MonthV2 =
   | 'Nov'
   | 'Dec';
 
-export function toIndexRouteV2(route: RouteV2, etag: string): IndexRouteV2 {
-  return omit({...route, etag}, ['description', 'geojson', 'url']);
+export function toIndexRouteV2(route: RouteV2): IndexRouteV2 {
+  return omit(route, ['description', 'geojson', 'url']);
 }
 
 function toGeoJSONRouteV2CoreProperties(

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -57,10 +57,10 @@ class Logger {
   /**
    * Call this method to report the start and end of a long-running task.
    */
-  step<T extends unknown[], U>(fn: (...args: T) => Promise<U>, args: T): Promise<U> {
+  step<T extends unknown[], U>(fn: (...args: T) => Promise<U> | U, args: T): Promise<U> | U {
     const startTime = Date.now();
     this.inner('log', [chalk.blue(chalk.bold(`Start ${fn.name}`))]);
-    const promise = fn(...args);
+    const promise = Promise.resolve(fn(...args));
     promise.then(() => {
       const timeString = ((Date.now() - startTime) / 1000).toLocaleString(undefined, {
         unit: 'second',


### PR DESCRIPTION
This PR adds a `version` property to the `IndexRouteV2` and `RouteV2` interfaces and removes the `IndexRouteV2`-only `etag` property. This new design makes working with the versioning data easier on clients. 